### PR TITLE
Replace PIL by Pillow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,6 @@ setup(
     packages=packages,
     package_data=package_data,
     scripts=[],
-    install_requires=['bleach', 'pil'],
+    install_requires=['bleach', 'Pillow'],
     setup_requires=['setuptools >= 3.3'],
 )


### PR DESCRIPTION
PIL is dead and no longer exist on PyPI, his actively maintained fork Pillow got a similar API.
