### PR TITLE
support for _NamespacePath, used as native namespace packages __path__ attribute

### DIFF
--- a/django_web_utils/packages_utils.py
+++ b/django_web_utils/packages_utils.py
@@ -16,7 +16,7 @@ def get_version(package=None, module=None):
     revision = ''
     if module:
         version = getattr(module, '__version__', '')
-        git_dir = module.__path__[0]
+        git_dir = list(module.__path__)[0]
         if os.path.islink(git_dir):
             git_dir = os.readlink(git_dir)
         if not os.path.exists(os.path.join(git_dir, '.git')):


### PR DESCRIPTION
A `django_web_utils.packages_utils.get_version()` used against a native namespace packages will broke since _NamespacePath is used as a type there.

This PR solve this issue (at least tested in local).